### PR TITLE
Fixes #7

### DIFF
--- a/verveinej.sh
+++ b/verveinej.sh
@@ -1,52 +1,36 @@
 #!/usr/bin/env bash
-
-if [ -z "$1" ]
-then
-	echo "Usage: verveinej.sh [ <jvm-options> -- ] [ <verveine-options> ] <java-source>" >&2
-	echo "  <verveine-options> from Eclipse JDT Batch Compiler:" >&2
-	echo "" >&2
-fi
+((ddashloc=0))
+((i=0))
+for f in "$@"; do
+  ((i++))
+  #echo "$f";
+  if [ "$f" == "--" ]
+  then
+    #echo " found the -- at $i"
+    ((ddashloc= $i+1))
+  fi
+done
 
 # Directory for verveine source
-BASELIB=`dirname $0`/lib
+BASELIB=`dirname "$0"`/lib
 
 # on windows, convert backslashes to slashes so that file expansion will work
 BASELIB=$(sed 's:\\:/:g' <<< "$BASELIB")
 
-# JVM options e.g. -Xmx2500m to augment maximum memory size of the vm to 2.5Go.
-JOPT=""
-# Verveine option
-VOPT=""
-
-# Any argument before "--" is for the JVM
-# Any argument after "--" is for verveine
-# Without "--" every argument goes to verveine
-while [ "$1" != "--" ] && [ "$1" != "" ]
-do
-	JOPT="$JOPT "$(printf %q "$1")
-	shift
-done
-
-if [ "$1" == "--" ]
-then
-	shift
-	VOPT=$*
-else
-	# without the special "--" argument, all options are assumed to be for Verveine
-	VOPT=$JOPT
-	JOPT=""
-fi
 pathsep=":"
 # handle path separator for flavors of windows (MINGW in LibC via Pharo)
 case $(uname) in
 MINGW*|CYGWIN*)
   pathsep=";"
 esac
-for i in $BASELIB/*.jar; do
-    CLASSPATH=$CLASSPATH$pathsep$i
+for i in "$BASELIB"/*.jar; do
+    CLASSPATH="$CLASSPATH"$pathsep"$i"
 done
 CLASSPATH=`echo $CLASSPATH | cut -c2-`
 
-#echo $CLASSPATH
-
-java $JOPT -cp $CLASSPATH fr.inria.verveine.extractor.java.VerveineJParser $VOPT
+if [ $ddashloc != 0 ]
+then
+  java ${@:1:(($ddashloc-2))} -cp "$CLASSPATH" fr.inria.verveine.extractor.java.VerveineJParser "${@:$ddashloc}" #-o "$msefile" "$sourcepath"
+else
+  java -cp "$CLASSPATH" fr.inria.verveine.extractor.java.VerveineJParser "${@:1}" #-o "$msefile" "$sourcepath"
+fi


### PR DESCRIPTION
This approach preserves `$@` so escaping of spaces in paths is not lost. To keep the syntax for the verveinej command with the `--` I had to do an if/then. I tested this with `MooseEasyFamixMaker` and with paths containing spaces and it works.